### PR TITLE
Fixed validators short proof

### DIFF
--- a/Casper.thy
+++ b/Casper.thy
@@ -1,0 +1,67 @@
+theory Casper
+imports Main
+begin
+
+locale byz_quorums =
+  fixes member_1 :: "'n \<Rightarrow> 'q1 \<Rightarrow> bool" (* membership in 2/3 set *)
+    and member_2 :: "'n \<Rightarrow> 'q2 \<Rightarrow> bool" (* membership in 1/3 set *)
+  assumes "\<And> q1 q2 . \<exists> q3 . \<forall> n . member_2 n q3 \<longrightarrow> member_1 n q1 \<and> member_1 n q2" (* 2/3 quorums have 1/3 intersection *)
+    and "\<And> q1 q2 . \<exists> n . member_2 n q1 \<and> member_1 n q2" (* 2/3 sets and 1/3 sets intersect *)
+
+record ('n,'h,'v)state =
+  -- "@{typ 'n} is the type of validators (nodes), @{typ 'h} hashes, and @{typ 'v} views"
+  commit_msg :: "'n \<Rightarrow> 'h \<Rightarrow> 'v \<Rightarrow> bool"
+  prepare_msg :: "'n \<Rightarrow> 'h \<Rightarrow> 'v \<Rightarrow> 'v \<Rightarrow> bool"
+
+locale casper = byz_quorums + 
+  hashes:order hash_less_eq hash_less + 
+  views:linorder view_less_eq view_less + 
+  order_bot bot for
+  hash_less_eq :: "'h \<Rightarrow> 'h \<Rightarrow> bool" (infix "\<le>\<^sub>h" 50)
+  and hash_less :: "'h \<Rightarrow> 'h \<Rightarrow> bool" (infix "<\<^sub>h" 50)
+  and view_less_eq :: "'v \<Rightarrow> 'v \<Rightarrow> bool" (infix "\<le>\<^sub>v" 50)
+  and view_less :: "'v \<Rightarrow> 'v \<Rightarrow> bool" (infix "<\<^sub>v" 50)
+  and bot::"'v" ("\<bottom>") +
+assumes "\<And> h1 h2 . \<lbrakk>h1 \<le>\<^sub>h h; h2 \<le>\<^sub>h h\<rbrakk> \<Longrightarrow> h1 \<le>\<^sub>h h2 \<or> h2 \<le>\<^sub>h h1"
+  -- "a hash has a unique parent"
+begin
+
+lemmas casper_assms = casper_axioms casper_def class.linorder_def class.order_def
+    class.preorder_def class.order_axioms_def class.linorder_axioms_def byz_quorums_def
+
+definition is_pred where "is_pred h1 h2 \<equiv> h1 <\<^sub>h h2 \<and> (\<forall> h . \<not> (h1 <\<^sub>h h \<and> h <\<^sub>h h2))"
+
+definition prepared where 
+  "prepared s q h v1 v2 \<equiv> \<forall> n . member_1 n q \<longrightarrow> prepare_msg s n h v1 v2"
+definition committed where
+  "committed s q h v \<equiv> \<forall> n . member_1 n q \<longrightarrow> commit_msg s n h v"
+definition fork where 
+  "fork s \<equiv> \<exists> h1 h2 q1 q2 v1 v2 . committed s q1 h1 v1 \<and> committed s q2 h2 v2
+    \<and> \<not>(h2 \<le>\<^sub>h h1 \<or> h1 \<le>\<^sub>h h2)"
+
+definition slashed_1 where  "slashed_1 s n \<equiv> 
+  \<exists> h v . commit_msg s n h v \<and> (\<forall> q v2 . v2 \<le>\<^sub>v v \<longrightarrow> \<not>prepared s q h v v2)"
+definition slashed_2 where "slashed_2 s n \<equiv>
+  \<exists> h v1 v2 . prepare_msg s n h v1 v2 \<and> v2 \<noteq> \<bottom> \<and>
+    (\<forall> v3 q h2 . v3 \<le>\<^sub>v v2 \<longrightarrow> \<not>(prepared s q h2 v2 v3 \<and> is_pred h2 h))"
+definition slashed_3 where "slashed_3 s n \<equiv>
+  \<exists> h1 h2 v1 v2 v3 . v1 <\<^sub>v v2 \<and> v3 <\<^sub>v v1 \<and> 
+    commit_msg s n h1 v1 \<and> prepare_msg s n h2 v2 v3"
+definition slashed_4 where "slashed_4 s n \<equiv>
+  \<exists> h1 h2 v v1 v2 . (h1 \<noteq> h2 \<or> v1 \<noteq> v2) \<and> 
+    prepare_msg s n h1 v v1 \<and> prepare_msg s n h2 v v2"
+definition slashed where "slashed s n \<equiv> 
+  slashed_1 s n \<or> slashed_2 s n \<or> slashed_3 s n \<or> slashed_4 s n"
+
+lemma assumes "fork s" 
+  shows "\<exists> q . \<forall> n . member_2 n q \<longrightarrow> slashed s n"
+  using [[show_types]]
+  nitpick[verbose, card 'b=2, card 'c=2, card 'a=5, card 'v=2, card 'h=3, card 'd=1,
+      card "('a, 'h, 'v, 'd) state_scheme" = 1, dont_box]
+
+end
+
+end
+
+
+end

--- a/Casper.thy
+++ b/Casper.thy
@@ -1,52 +1,56 @@
 theory Casper
-imports Main "HOL-Eisbach.Eisbach" Inductive
+  imports Main
 begin
 
-locale byz_quorums =
-  fixes member_1 :: "'n \<Rightarrow> 'q1 \<Rightarrow> bool" (infix "\<in>\<^sub>1" 50)(* membership in 2/3 set *)
-    and member_2 :: "'n \<Rightarrow> 'q2 \<Rightarrow> bool" (infix "\<in>\<^sub>2" 50)(* membership in 1/3 set *)
-  assumes "\<And> q1 q2 . \<exists> q3 . \<forall> n . n \<in>\<^sub>2 q3 \<longrightarrow> n \<in>\<^sub>1 q1 \<and> n \<in>\<^sub>1 q2"  (* 2/3 quorums have 1/3 intersection *)
+text {* We use first-order modeling as much as possible. This allows to reduce the size of the model, 
+  and also the size of the proofs from more than 1000 lines in Yoichi's proof to less than a 100. *}
 
-record ('n,'h,'v)state =
-  -- "@{typ 'n} is the type of validators (nodes), @{typ 'h} hashes, and @{typ nat} views"
+locale byz_quorums =
+  -- "Here we fix two types @{typ 'q1} and @{typ 'q2} for quorums of cardinality greater than 2/3 of 
+the validators and quorum of cardinality greater than 1/3 of the validators."
+  fixes member_1 :: "'n \<Rightarrow> 'q1 \<Rightarrow> bool" (infix "\<in>\<^sub>1" 50)
+    -- "Membership in 2/3 set"
+    and member_2 :: "'n \<Rightarrow> 'q2 \<Rightarrow> bool" (infix "\<in>\<^sub>2" 50)
+    -- "Membership in 1/3 set"
+  assumes "\<And> q1 q2 . \<exists> q3 . \<forall> n . n \<in>\<^sub>2 q3 \<longrightarrow> n \<in>\<^sub>1 q1 \<and> n \<in>\<^sub>1 q2"  
+    -- "This is the only property of types @{typ 'q1} and @{typ 'q2} that we need: 
+2/3 quorums have 1/3 intersection"
+
+record ('n,'h)state =
+  -- "@{typ 'n} is the type of validators (nodes), @{typ 'h} hashes, and views are @{typ nat}"
   commit_msg :: "'n \<Rightarrow> 'h \<Rightarrow> nat \<Rightarrow> bool"
-  prepare_msg :: "'n \<Rightarrow> 'h \<Rightarrow> nat \<Rightarrow> 'v \<Rightarrow> bool"
+  prepare_msg :: "'n \<Rightarrow> 'h \<Rightarrow> nat \<Rightarrow> nat \<Rightarrow> bool"
 
 locale casper = byz_quorums +
+  -- "Here we make assumptions about hashes. In reality any message containing a hash not satisfying those
+should be dropped."
 fixes 
   hash_parent :: "'h \<Rightarrow> 'h \<Rightarrow> bool" (infix "\<leftarrow>" 50)
 assumes
-  -- "a hash has at most one predecessor which is not itself"
+  -- "a hash has at most one parent which is not itself"
   "\<And> h1 h2 . h1 \<leftarrow> h2 \<Longrightarrow> h1 \<noteq> h2"
   and "\<And> h1 h2 h3 . \<lbrakk>h2 \<leftarrow> h1; h3 \<leftarrow> h1\<rbrakk> \<Longrightarrow> h2 = h3"
 begin
+
+lemmas casper_assms_def = casper_def casper_axioms_def byz_quorums_def
 
 inductive hash_ancestor (infix "\<leftarrow>\<^sup>*" 50) where 
   "h1 \<leftarrow> h2 \<Longrightarrow> h1 \<leftarrow>\<^sup>* h2"
 | "\<lbrakk>h1 \<leftarrow> h2; h2 \<leftarrow>\<^sup>* h3\<rbrakk> \<Longrightarrow> h1 \<leftarrow>\<^sup>* h3"
 declare hash_ancestor.intros[simp,intro]
-lemma hash_ancestor_intro': assumes "h1 \<leftarrow>\<^sup>* h2" and "h2 \<leftarrow> h3" shows "h1 \<leftarrow>\<^sup>* h3" using assms
-  by (induct h1 h2 rule:hash_ancestor.induct) auto
+lemma hash_ancestor_intro': assumes "h1 \<leftarrow>\<^sup>* h2" and "h2 \<leftarrow> h3" shows "h1 \<leftarrow>\<^sup>* h3" 
+  using assms by (induct h1 h2 rule:hash_ancestor.induct) auto
 
 inductive nth_ancestor :: "nat \<Rightarrow> 'h \<Rightarrow> 'h \<Rightarrow> bool" where 
   "nth_ancestor 0 h1 h1"
 | "\<lbrakk>nth_ancestor n h1 h2; h2 \<leftarrow> h3\<rbrakk> \<Longrightarrow> nth_ancestor (n+1) h1 h3"
 declare nth_ancestor.intros[simp,intro]
-
 inductive_cases nth_ancestor_succ:"nth_ancestor (n+1) h1 h3"
 inductive_cases zeroth_ancestor:"nth_ancestor 0 h1 h3"
-
 lemma parent_ancestor:"h1 \<leftarrow> h2 = nth_ancestor 1 h1 h2"
   by (metis One_nat_def add.right_neutral add_Suc_right add_diff_cancel_left' diff_Suc_Suc nat.simps(3) nth_ancestor.simps)
 
-lemma "\<lbrakk>nth_ancestor (n+1) h1 h2; h3 \<leftarrow> h2\<rbrakk> \<Longrightarrow> nth_ancestor n h1 h3"
-  by (metis casper.axioms(2) casper_axioms casper_axioms_def nth_ancestor_succ)
-  
-lemmas casper_assms_def = casper_def casper_axioms_def byz_quorums_def
-
-text {* All messages in epoch @{term 0} are ignored;  @{term 0} is used as a special value.
-  This appears in the following definitions. *}
-
+text {* All messages in epoch @{term "0::nat"} are ignored;  @{term "0::nat"} is used as a special value (was @{term "-1::int"} in the original model). *}
 definition prepared' where
   "prepared' s q h v1 v2 \<equiv> v1 \<noteq> 0 \<and> (\<forall> n . n \<in>\<^sub>1 q \<longrightarrow> prepare_msg s n h v1 v2)"
 definition prepared where
@@ -63,11 +67,6 @@ definition slashed_2 where
   "slashed_2 s n \<equiv>
   \<exists> h v1 v2 . prepare_msg s n h v1 v2 \<and> v2 \<noteq> 0 \<and>
     (\<forall> v3 q h2 . v3 < v2 \<longrightarrow> \<not>(nth_ancestor (v1 - v2) h2 h \<and> prepared s q h2 v2 v3))"
-definition slashed_2' where
-  -- "this is not what Vitalik wrote, but works too."
-  "slashed_2' s n \<equiv>
-  \<exists> h v1 v2 . prepare_msg s n h v1 v2 \<and> v2 \<noteq> 0 \<and>
-    (\<forall> v3 q h2 . v3 < v2 \<longrightarrow> \<not>(h2 \<leftarrow> h \<and> prepared s q h2 v2 v3))"
 definition slashed_3 where 
   "slashed_3 s n \<equiv>
   \<exists> h1 h2 v1 v2 v3 . v1 < v2 \<and> v3 < v1 \<and> 
@@ -85,40 +84,30 @@ lemmas casper_defs = slashed_defs prepared_def fork_def committed_def casper_ass
 
 lemma l1: assumes "prepared s q1 h1 v1 v2" and "committed s q2 h2 v3" and "v1 > v3" and "\<not>one_third_slashed s"
   shows "v1 > v2 \<and> v2 \<ge> v3"
-  nitpick[verbose, card 'b=1, card 'c=1, card 'a=1, card nat=5, card 'h=4, card 'd=1,
-      card "('a, 'h, nat, 'd) state_scheme" = 1, dont_box, timeout=300, eval="fork s"]
-  using assms casper_axioms linorder_axioms[where ?'a=nat]
-  unfolding casper_defs order_defs
+(*<*)  nitpick[verbose, card 'b=1, card 'c=1, card 'a=1, card nat=5, card 'h=4, card 'd=1,
+      card "('a, 'h, 'd) state_scheme" = 1, dont_box, timeout=300, eval="fork s"] (*>*)
+  using assms casper_axioms linorder_axioms[where ?'a=nat] unfolding casper_defs order_defs
   by smt
 
 lemma l2: assumes "nth_ancestor n h1 h2" and "nth_ancestor m h2 h3" 
   shows "nth_ancestor (n+m) h1 h3" 
   using assms 
 proof (induct m arbitrary: h1 h2 h3)
-  case 0
-  then show ?case using nth_ancestor.cases by auto
+  case 0 then show ?case using nth_ancestor.cases by auto
 next
   case (Suc m)
-  then show ?case
-    by (metis Suc_eq_plus1 add_Suc_right nth_ancestor.simps nth_ancestor_succ)
+  then show ?case by (metis Suc_eq_plus1 add_Suc_right nth_ancestor.simps nth_ancestor_succ)
 qed
 
 lemma l3: assumes "prepared s q1 h1 v1 v2" and "committed s q2 h2 v3" and "v1 > v3" and "\<not>one_third_slashed s"
   shows "nth_ancestor (v1 - v3) h2 h1"
-  nitpick[verbose, card 'b=1, card 'c=1, card 'a=1, card nat=5, card 'h=4, card 'd=1,
-      card "('a, 'h, nat, 'd) state_scheme" = 1, dont_box, timeout=300, eval="fork s"]
 proof -
   show ?thesis using assms
   proof (induct "v1 - v3" arbitrary: v1 v2 v3 q1 q2 h1 h2 rule:less_induct)
-    case less
-    then show ?case 
+    case less then show ?case 
     proof (cases "v1-v3=0")
-      case True
-      then show ?thesis
-        using less.prems(3) by linarith 
-    next
-      case False
-      then show ?thesis
+      case True then show ?thesis using less.prems(3) by linarith  next
+      case False then show ?thesis
       proof (cases "v2=v3")
         case True
         then show ?thesis using less(2-5) casper_axioms linorder_axioms[where ?'a=nat]
@@ -136,12 +125,9 @@ proof -
   qed
 qed
 
-lemma l4:assumes "nth_ancestor n (h1::'h) h2"
-  shows "h1 \<leftarrow>\<^sup>* h2 \<or> h1 = h2"
-  using assms
+lemma l4:assumes "nth_ancestor n (h1::'h) h2" shows "h1 \<leftarrow>\<^sup>* h2 \<or> h1 = h2" using assms
 proof (induct n arbitrary:h1 h2)
-  case 0
-  then show ?case using zeroth_ancestor by auto
+  case 0 then show ?case using zeroth_ancestor by auto
 next
   case (Suc n)
   obtain h3 where 1:"h3 \<leftarrow> h2" and 2:"nth_ancestor n h1 h3" using nth_ancestor_succ Suc.prems by (metis Suc_eq_plus1) 
@@ -158,30 +144,14 @@ proof -
   show ?thesis 
   proof (cases "v1 = v2")
     case True
-    show ?thesis using 1 4 2 5 6 True casper_axioms unfolding byz_quorums_def casper_def
-      one_third_slashed_def casper_axioms committed_def prepared_def slashed_1_def slashed_4_def slashed_def
+    show ?thesis using 1 4 2 5 6 True casper_axioms unfolding byz_quorums_def casper_def  slashed_def
+      one_third_slashed_def casper_axioms committed_def prepared_def slashed_1_def slashed_4_def
       by metis
   next
-    case False
-    thus ?thesis using l3 1 2 4 5 6
-      by (metis less_le not_less)
+    case False thus ?thesis using l3 1 2 4 5 6 by (metis less_le not_less)
   qed
 qed
 
-text "Just two observations:"
-
-lemma assumes "\<not>one_third_slashed s" and "committed s q1 h1 v1" and "committed s q2 h2 v2"
-  and "h1 \<leftarrow>\<^sup>* h2" and "h2 \<leftarrow>\<^sup>* h1" shows False
-  nitpick[verbose, card 'b=1, card 'c=1, card 'a=1, card nat=3, card 'h=2, card 'd=1,
-      card "('a, 'h, nat, 'd) state_scheme" = 1, dont_box, timeout=300, eval="(\<lambda> h v1 v2 . \<exists> q . prepared s q h v1 v2)"]
-  -- "The slashing conditions allow loops in the block chain."
-  oops
-
-lemma assumes "\<not>one_third_slashed s" and "committed s q h v"
-  obtains q0 h0 v0 where "prepared s q0 h0 1 v0"
-  nitpick[verbose, card 'b=1, card 'c=1, card 'a=1, card nat=3, card 'h=2, card 'd=1,
-      card "('a, 'h, nat, 'd) state_scheme" = 1, dont_box, timeout=300, eval="fork s"]
-  -- "The slashing conditions allow a chain not anchored at 0."
-  oops
+end
 
 end

--- a/Casper.thy
+++ b/Casper.thy
@@ -1,13 +1,11 @@
 theory Casper
-imports Main "Eisbach"
+imports Main "HOL-Eisbach.Eisbach" Inductive
 begin
 
 locale byz_quorums =
   fixes member_1 :: "'n \<Rightarrow> 'q1 \<Rightarrow> bool" (infix "\<in>\<^sub>1" 50)(* membership in 2/3 set *)
     and member_2 :: "'n \<Rightarrow> 'q2 \<Rightarrow> bool" (infix "\<in>\<^sub>2" 50)(* membership in 1/3 set *)
   assumes "\<And> q1 q2 . \<exists> q3 . \<forall> n . n \<in>\<^sub>2 q3 \<longrightarrow> n \<in>\<^sub>1 q1 \<and> n \<in>\<^sub>1 q2"  (* 2/3 quorums have 1/3 intersection *)
-    (* and "\<And> q1 q2 . \<exists> n . n \<in>\<^sub>2 q1 \<and> n \<in>\<^sub>1 q2" *) (* 2/3 sets and 1/3 sets intersect *)
-    (* and "\<And> q . \<exists> n . n \<in>\<^sub>2 q" *)
 
 record ('n,'h,'v)state =
   -- "@{typ 'n} is the type of validators (nodes), @{typ 'h} hashes, and @{typ nat} views"
@@ -16,7 +14,7 @@ record ('n,'h,'v)state =
 
 locale casper = byz_quorums +
 fixes 
-  hash_pred :: "'h \<Rightarrow> 'h \<Rightarrow> bool" (infix "\<leftarrow>" 50)
+  hash_parent :: "'h \<Rightarrow> 'h \<Rightarrow> bool" (infix "\<leftarrow>" 50)
 assumes
   -- "a hash has at most one predecessor which is not itself"
   "\<And> h1 h2 . h1 \<leftarrow> h2 \<Longrightarrow> h1 \<noteq> h2"
@@ -27,37 +25,51 @@ inductive hash_ancestor (infix "\<leftarrow>\<^sup>*" 50) where
   "h1 \<leftarrow> h2 \<Longrightarrow> h1 \<leftarrow>\<^sup>* h2"
 | "\<lbrakk>h1 \<leftarrow> h2; h2 \<leftarrow>\<^sup>* h3\<rbrakk> \<Longrightarrow> h1 \<leftarrow>\<^sup>* h3"
 declare hash_ancestor.intros[simp,intro]
+lemma hash_ancestor_intro': assumes "h1 \<leftarrow>\<^sup>* h2" and "h2 \<leftarrow> h3" shows "h1 \<leftarrow>\<^sup>* h3" using assms
+  by (induct h1 h2 rule:hash_ancestor.induct) auto
 
-inductive nth_parent :: "nat \<Rightarrow> 'h \<Rightarrow> 'h \<Rightarrow> bool" where 
-  "nth_parent 0 h1 h1"
-| "\<lbrakk>nth_parent n h1 h2; h2 \<leftarrow> h3\<rbrakk> \<Longrightarrow> nth_parent (n+1) h1 h3"
-declare nth_parent.intros[simp,intro]
+inductive nth_ancestor :: "nat \<Rightarrow> 'h \<Rightarrow> 'h \<Rightarrow> bool" where 
+  "nth_ancestor 0 h1 h1"
+| "\<lbrakk>nth_ancestor n h1 h2; h2 \<leftarrow> h3\<rbrakk> \<Longrightarrow> nth_ancestor (n+1) h1 h3"
+declare nth_ancestor.intros[simp,intro]
 
-inductive_cases test2:"nth_parent 1 h1 h2"
-thm test2
+inductive_cases nth_ancestor_succ:"nth_ancestor (n+1) h1 h3"
+inductive_cases zeroth_ancestor:"nth_ancestor 0 h1 h3"
 
-lemmas casper_assms_def = casper_def casper_axioms_def class.linorder_def class.order_def
-    class.preorder_def class.order_axioms_def class.linorder_axioms_def byz_quorums_def
-    class.order_bot_def class.order_bot_axioms_def
+lemma parent_ancestor:"h1 \<leftarrow> h2 = nth_ancestor 1 h1 h2"
+  by (metis One_nat_def add.right_neutral add_Suc_right add_diff_cancel_left' diff_Suc_Suc nat.simps(3) nth_ancestor.simps)
 
-text {* All messages in epoch @{term 0} are ignored;  @{term 0} is used as a special value. *}
+lemma "\<lbrakk>nth_ancestor (n+1) h1 h2; h3 \<leftarrow> h2\<rbrakk> \<Longrightarrow> nth_ancestor n h1 h3"
+  by (metis casper.axioms(2) casper_axioms casper_axioms_def nth_ancestor_succ)
+  
+lemmas casper_assms_def = casper_def casper_axioms_def byz_quorums_def
 
-definition prepared where 
-  "prepared s q h v1 v2 \<equiv> v1 \<noteq> 0 \<and> (\<forall> n . n \<in>\<^sub>1 q \<longrightarrow> prepare_msg s n h v1 v2)"
+lemma "h1 \<leftarrow>\<^sup>* h2 \<Longrightarrow> \<not> h2 \<leftarrow>\<^sup>* h1" 
+  nitpick[no_assms,verbose, card 'h=2, eval="(op \<leftarrow>,UNIV::'h set)"]
+    -- "The definition allows loops."
+  oops
+
+  text {* All messages in epoch @{term 0} are ignored;  @{term 0} is used as a special value. 
+  This appears in the following definitions. *}
+
+definition prepared' where
+  "prepared' s q h v1 v2 \<equiv> v1 \<noteq> 0 \<and> (\<forall> n . n \<in>\<^sub>1 q \<longrightarrow> prepare_msg s n h v1 v2)"
+definition prepared where
+  "prepared s q h v1 v2 \<equiv> v1 \<noteq> 0 \<and> v2 < v1 \<and> (\<forall> n . n \<in>\<^sub>1 q \<longrightarrow> prepare_msg s n h v1 v2)"
 definition committed where
   "committed s q h v \<equiv> v \<noteq> 0 \<and> (\<forall> n . n \<in>\<^sub>1 q \<longrightarrow> commit_msg s n h v)"
 definition fork where 
   "fork s \<equiv> \<exists> h1 h2 q1 q2 v1 v2 . committed s q1 h1 v1 \<and> committed s q2 h2 v2
     \<and> \<not>(h2 \<leftarrow>\<^sup>* h1 \<or> h1 \<leftarrow>\<^sup>* h2 \<or> h1 = h2)"
 
-definition slashed_1 where  "slashed_1 s n \<equiv> 
+definition slashed_1 where  "slashed_1 s n \<equiv>
   \<exists> h v . commit_msg s n h v \<and> (\<forall> q v2 . v2 < v \<longrightarrow> \<not>prepared s q h v v2)"
 definition slashed_2 where
   "slashed_2 s n \<equiv>
   \<exists> h v1 v2 . prepare_msg s n h v1 v2 \<and> v2 \<noteq> 0 \<and>
-    (\<forall> v3 q h2 . v3 < v2 \<longrightarrow> \<not>(nth_parent (v1 - v2) h2 h \<and> prepared s q h2 v2 v3))"
+    (\<forall> v3 q h2 . v3 < v2 \<longrightarrow> \<not>(nth_ancestor (v1 - v2) h2 h \<and> prepared s q h2 v2 v3))"
 definition slashed_2' where
-  -- "this is not exactly what Vitalik wrote."
+  -- "this is not what Vitalik wrote, but works too."
   "slashed_2' s n \<equiv>
   \<exists> h v1 v2 . prepare_msg s n h v1 v2 \<and> v2 \<noteq> 0 \<and>
     (\<forall> v3 q h2 . v3 < v2 \<longrightarrow> \<not>(h2 \<leftarrow> h \<and> prepared s q h2 v2 v3))"
@@ -68,48 +80,111 @@ definition slashed_3 where
 definition slashed_4 where
   "slashed_4 s n \<equiv> \<exists> h1 h2 v v1 v2 . (h1 \<noteq> h2 \<or> v1 \<noteq> v2) \<and> 
     prepare_msg s n h1 v v1 \<and> prepare_msg s n h2 v v2"
-
 definition slashed where "slashed s n \<equiv> 
   slashed_1 s n \<or> slashed_2 s n \<or> slashed_3 s n \<or> slashed_4 s n"
+definition one_third_slashed where "one_third_slashed s \<equiv> \<exists> q . \<forall> n . n \<in>\<^sub>2 q \<longrightarrow> slashed s n"
+lemmas slashed_defs = slashed_def slashed_1_def slashed_2_def slashed_4_def slashed_3_def one_third_slashed_def
 
-lemma assumes "prepared s q h1 v1 v2" and "committed s q h2 v2" and "v1 > v2"
-  and "\<not>nth_parent (v1 - v2) h2 h1"
-shows "\<exists> q . \<forall> n . n \<in>\<^sub>2 q \<longrightarrow> slashed s n"
-  using assms
-proof (induct "v1 - v2 - 1")
+lemmas order_defs = class.linorder_axioms_def class.linorder_def class.order_def class.preorder_def class.order_axioms_def class.order_bot_def class.order_bot_axioms_def linorder_axioms[where ?'a=nat]
+lemmas casper_defs = slashed_defs prepared_def fork_def committed_def casper_assms_def
+
+lemma assumes "\<not>one_third_slashed s" and "committed s q1 h1 v1" and "committed s q2 h2 v2"
+  and "h1 \<leftarrow>\<^sup>* h2" and "h2 \<leftarrow>\<^sup>* h1" shows False
+  nitpick[verbose, card 'b=1, card 'c=1, card 'a=1, card nat=3, card 'h=2, card 'd=1,
+      card "('a, 'h, nat, 'd) state_scheme" = 1, dont_box, timeout=300, eval="(\<lambda> h v1 v2 . \<exists> q . prepared s q h v1 v2)"]
+  -- "The slashing conditions allow loops in the block chain."
+  oops
+
+lemma assumes "\<not>one_third_slashed s" and "committed s q h v"
+  obtains q0 h0 v0 where "prepared s q0 h0 1 v0"
+  nitpick[verbose, card 'b=1, card 'c=1, card 'a=1, card nat=3, card 'h=2, card 'd=1,
+      card "('a, 'h, nat, 'd) state_scheme" = 1, dont_box, timeout=300, eval="fork s"]
+  -- "The slashing conditions allow a chain not anchored at 0."
+  oops
+
+lemma l1: assumes "prepared s q1 h1 v1 v2" and "committed s q2 h2 v3" and "v1 > v3" and "\<not>one_third_slashed s"
+  shows "v1 > v2 \<and> v2 \<ge> v3"
+  nitpick[verbose, card 'b=1, card 'c=1, card 'a=1, card nat=5, card 'h=4, card 'd=1,
+      card "('a, 'h, nat, 'd) state_scheme" = 1, dont_box, timeout=300, eval="fork s"]
+  using assms casper_axioms linorder_axioms[where ?'a=nat]
+  unfolding casper_defs order_defs
+  by smt
+
+lemma l2: assumes "nth_ancestor n h1 h2" and "nth_ancestor m h2 h3" 
+  shows "nth_ancestor (n+m) h1 h3" 
+  using assms 
+proof (induct m arbitrary: h1 h2 h3)
   case 0
-  have "\<not>h2 \<leftarrow> h1"
-    by (metis "0.hyps" Nat.add_0_right One_nat_def Suc_diff_Suc add_Suc_right assms(3) assms(4) diff_diff_left nth_parent.intros(1) nth_parent.intros(2))  
-  then show ?case using 0
-  using assms casper_axioms nth_parent.intros
-  unfolding slashed_def slashed_1_def slashed_2_def slashed_4_def slashed_3_def
-      prepared_def fork_def committed_def casper_assms_def
-  apply auto
-  using [[smt_infer_triggers,smt_timeout=3000,smt_oracle=true,smt_random_seed=3143,smt_certificates="./casper.cert"]]
+  then show ?case using nth_ancestor.cases by auto
 next
-  case (Suc x)
-  then show ?case sorry
-qed oops
+  case (Suc m)
+  then show ?case
+    by (metis Suc_eq_plus1 add_Suc_right nth_ancestor.simps nth_ancestor_succ)
+qed
 
-lemma assumes "fork s"
-  shows "\<exists> q . \<forall> n . n \<in>\<^sub>2 q \<longrightarrow> slashed s n" oops
-  using [[]]
-  nitpick[verbose, card 'b=2, card 'c=2, card 'a=5, card nat=5, card 'h=4, card 'd=1,
-      card "('a, 'h, nat, 'd) state_scheme" = 1, dont_box, timeout=300] (*,
-      eval="(slashed s, committed s)"] *)
-  using assms casper_axioms
-  apply -
-  unfolding slashed_def slashed_1_def slashed_2_def slashed_4_def slashed_3_def
-      prepared_def fork_def committed_def
-  apply (cases s)
-  apply simp
-  using hash_ancestor.intros nth_parent.intros
-  unfolding casper_assms_def
-  apply (simp (no_asm_use))
-  apply (match premises in P[thin]:"?x = ?y" \<Rightarrow> \<open>-\<close>)
-  apply clarify oops
-  using [[smt_infer_triggers,smt_timeout=3000,smt_oracle=true,smt_random_seed=8789797972,smt_certificates="./casper.cert"]]
-  sledgehammer[timeout=5000, provers=z3 spass]()
+lemma l3: assumes "prepared s q1 h1 v1 v2" and "committed s q2 h2 v3" and "v1 > v3" and "\<not>one_third_slashed s"
+  shows "nth_ancestor (v1 - v3) h2 h1"
+  nitpick[verbose, card 'b=1, card 'c=1, card 'a=1, card nat=5, card 'h=4, card 'd=1,
+      card "('a, 'h, nat, 'd) state_scheme" = 1, dont_box, timeout=300, eval="fork s"]
+proof -
+  show ?thesis using assms
+  proof (induct "v1 - v3" arbitrary: v1 v2 v3 q1 q2 h1 h2 rule:less_induct)
+    case less
+    then show ?case 
+    proof (cases "v1-v3=0")
+      case True
+      then show ?thesis
+        using less.prems(3) by linarith 
+    next
+      case False
+      then show ?thesis
+      proof (cases "v2=v3")
+        case True
+        then show ?thesis using less(2-5) casper_axioms linorder_axioms[where ?'a=nat]
+          using [[smt_solver=cvc4]] by (simp add: casper_defs, unfold order_defs) smt
+      next
+        case False
+        obtain q3 h3 v4 where 1:"nth_ancestor (v1-v2) h3 h1" and 2:"prepared s q3 h3 v2 v4"
+          by (metis less.prems(1-3) assms(4) byz_quorums_axioms byz_quorums_def committed_def diff_is_0_eq diff_zero l1 one_third_slashed_def prepared_def slashed_2_def slashed_def)
+        have 3:"nth_ancestor (v2-v3) h2 h3"
+          by (metis False 2 l1 diff_less_mono less.hyps less.prems less_le)
+        have 4:"v1 > v2 \<and> v2 \<ge> v3" using assms casper.l1 casper_axioms less.prems(1-3) by metis
+        show ?thesis using 1 3 4 less.prems(3) l2 by force
+      qed
+    qed
+  qed
+qed
 
+lemma l4:assumes "nth_ancestor n (h1::'h) h2"
+  shows "h1 \<leftarrow>\<^sup>* h2 \<or> h1 = h2"
+  using assms
+proof (induct n arbitrary:h1 h2)
+  case 0
+  then show ?case using zeroth_ancestor by auto
+next
+  case (Suc n)
+  obtain h3 where 1:"h3 \<leftarrow> h2" and 2:"nth_ancestor n h1 h3" using nth_ancestor_succ Suc.prems by (metis Suc_eq_plus1) 
+  show ?case using Suc.hyps[OF 2] 1 hash_ancestor_intro' by blast 
+qed
+
+lemma safety: assumes "fork s" shows "one_third_slashed s"
+proof -
+  obtain h1 h2 q1 q2 v1 v2 where 1:"committed s q1 h1 v1" and 2:"committed s q2 h2 v2" 
+    and 3:"\<not> (h2 \<leftarrow>\<^sup>* h1 \<or> h1 \<leftarrow>\<^sup>* h2 \<or> h1 = h2)" using assms fork_def by blast
+  have 4:"\<not>(nth_ancestor n h1 h2 \<or> nth_ancestor n h2 h1 \<or> h1 = h2)" for n using l4 3 by auto
+  obtain q3 q4 v3 v4 where 5:"prepared s q3 h1 v1 v3" and 6:"prepared s q4 h2 v2 v4" if "\<not>one_third_slashed s" using 1 2
+    by (metis byz_quorums_axioms byz_quorums_def committed_def one_third_slashed_def slashed_1_def slashed_def)
+  show ?thesis 
+  proof (cases "v1 = v2")
+    case True
+    show ?thesis using 1 4 2 5 6 True casper_axioms unfolding byz_quorums_def casper_def
+      one_third_slashed_def casper_axioms committed_def prepared_def slashed_1_def slashed_4_def slashed_def
+      by metis
+  next
+    case False
+    thus ?thesis using l3 1 2 4 5 6
+      by (metis less_le not_less)
+  qed
+qed
 
 end

--- a/Casper.thy
+++ b/Casper.thy
@@ -44,12 +44,7 @@ lemma "\<lbrakk>nth_ancestor (n+1) h1 h2; h3 \<leftarrow> h2\<rbrakk> \<Longrigh
   
 lemmas casper_assms_def = casper_def casper_axioms_def byz_quorums_def
 
-lemma "h1 \<leftarrow>\<^sup>* h2 \<Longrightarrow> \<not> h2 \<leftarrow>\<^sup>* h1" 
-  nitpick[no_assms,verbose, card 'h=2, eval="(op \<leftarrow>,UNIV::'h set)"]
-    -- "The definition allows loops."
-  oops
-
-  text {* All messages in epoch @{term 0} are ignored;  @{term 0} is used as a special value. 
+text {* All messages in epoch @{term 0} are ignored;  @{term 0} is used as a special value.
   This appears in the following definitions. *}
 
 definition prepared' where
@@ -87,20 +82,6 @@ lemmas slashed_defs = slashed_def slashed_1_def slashed_2_def slashed_4_def slas
 
 lemmas order_defs = class.linorder_axioms_def class.linorder_def class.order_def class.preorder_def class.order_axioms_def class.order_bot_def class.order_bot_axioms_def linorder_axioms[where ?'a=nat]
 lemmas casper_defs = slashed_defs prepared_def fork_def committed_def casper_assms_def
-
-lemma assumes "\<not>one_third_slashed s" and "committed s q1 h1 v1" and "committed s q2 h2 v2"
-  and "h1 \<leftarrow>\<^sup>* h2" and "h2 \<leftarrow>\<^sup>* h1" shows False
-  nitpick[verbose, card 'b=1, card 'c=1, card 'a=1, card nat=3, card 'h=2, card 'd=1,
-      card "('a, 'h, nat, 'd) state_scheme" = 1, dont_box, timeout=300, eval="(\<lambda> h v1 v2 . \<exists> q . prepared s q h v1 v2)"]
-  -- "The slashing conditions allow loops in the block chain."
-  oops
-
-lemma assumes "\<not>one_third_slashed s" and "committed s q h v"
-  obtains q0 h0 v0 where "prepared s q0 h0 1 v0"
-  nitpick[verbose, card 'b=1, card 'c=1, card 'a=1, card nat=3, card 'h=2, card 'd=1,
-      card "('a, 'h, nat, 'd) state_scheme" = 1, dont_box, timeout=300, eval="fork s"]
-  -- "The slashing conditions allow a chain not anchored at 0."
-  oops
 
 lemma l1: assumes "prepared s q1 h1 v1 v2" and "committed s q2 h2 v3" and "v1 > v3" and "\<not>one_third_slashed s"
   shows "v1 > v2 \<and> v2 \<ge> v3"
@@ -186,5 +167,21 @@ proof -
       by (metis less_le not_less)
   qed
 qed
+
+text "Just two observations:"
+
+lemma assumes "\<not>one_third_slashed s" and "committed s q1 h1 v1" and "committed s q2 h2 v2"
+  and "h1 \<leftarrow>\<^sup>* h2" and "h2 \<leftarrow>\<^sup>* h1" shows False
+  nitpick[verbose, card 'b=1, card 'c=1, card 'a=1, card nat=3, card 'h=2, card 'd=1,
+      card "('a, 'h, nat, 'd) state_scheme" = 1, dont_box, timeout=300, eval="(\<lambda> h v1 v2 . \<exists> q . prepared s q h v1 v2)"]
+  -- "The slashing conditions allow loops in the block chain."
+  oops
+
+lemma assumes "\<not>one_third_slashed s" and "committed s q h v"
+  obtains q0 h0 v0 where "prepared s q0 h0 1 v0"
+  nitpick[verbose, card 'b=1, card 'c=1, card 'a=1, card nat=3, card 'h=2, card 'd=1,
+      card "('a, 'h, nat, 'd) state_scheme" = 1, dont_box, timeout=300, eval="fork s"]
+  -- "The slashing conditions allow a chain not anchored at 0."
+  oops
 
 end

--- a/Casper.thy
+++ b/Casper.thy
@@ -1,67 +1,89 @@
 theory Casper
-imports Main
+imports Main "Eisbach"
 begin
 
 locale byz_quorums =
-  fixes member_1 :: "'n \<Rightarrow> 'q1 \<Rightarrow> bool" (* membership in 2/3 set *)
-    and member_2 :: "'n \<Rightarrow> 'q2 \<Rightarrow> bool" (* membership in 1/3 set *)
-  assumes "\<And> q1 q2 . \<exists> q3 . \<forall> n . member_2 n q3 \<longrightarrow> member_1 n q1 \<and> member_1 n q2" (* 2/3 quorums have 1/3 intersection *)
-    and "\<And> q1 q2 . \<exists> n . member_2 n q1 \<and> member_1 n q2" (* 2/3 sets and 1/3 sets intersect *)
+  fixes member_1 :: "'n \<Rightarrow> 'q1 \<Rightarrow> bool" (infix "\<in>\<^sub>1" 50)(* membership in 2/3 set *)
+    and member_2 :: "'n \<Rightarrow> 'q2 \<Rightarrow> bool" (infix "\<in>\<^sub>2" 50)(* membership in 1/3 set *)
+  assumes "\<And> q1 q2 . \<exists> q3 . \<forall> n . n \<in>\<^sub>2 q3 \<longrightarrow> n \<in>\<^sub>1 q1 \<and> n \<in>\<^sub>1 q2"  (* 2/3 quorums have 1/3 intersection *)
+    (* and "\<And> q1 q2 . \<exists> n . n \<in>\<^sub>2 q1 \<and> n \<in>\<^sub>1 q2" *) (* 2/3 sets and 1/3 sets intersect *)
+    (* and "\<And> q . \<exists> n . n \<in>\<^sub>2 q" *)
 
 record ('n,'h,'v)state =
   -- "@{typ 'n} is the type of validators (nodes), @{typ 'h} hashes, and @{typ 'v} views"
   commit_msg :: "'n \<Rightarrow> 'h \<Rightarrow> 'v \<Rightarrow> bool"
   prepare_msg :: "'n \<Rightarrow> 'h \<Rightarrow> 'v \<Rightarrow> 'v \<Rightarrow> bool"
 
-locale casper = byz_quorums + 
-  hashes:order hash_less_eq hash_less + 
+locale casper = byz_quorums +
   views:linorder view_less_eq view_less + 
-  order_bot bot for
+  order_bot  bot view_less_eq view_less for
   hash_less_eq :: "'h \<Rightarrow> 'h \<Rightarrow> bool" (infix "\<le>\<^sub>h" 50)
   and hash_less :: "'h \<Rightarrow> 'h \<Rightarrow> bool" (infix "<\<^sub>h" 50)
   and view_less_eq :: "'v \<Rightarrow> 'v \<Rightarrow> bool" (infix "\<le>\<^sub>v" 50)
   and view_less :: "'v \<Rightarrow> 'v \<Rightarrow> bool" (infix "<\<^sub>v" 50)
-  and bot::"'v" ("\<bottom>") +
-assumes "\<And> h1 h2 . \<lbrakk>h1 \<le>\<^sub>h h; h2 \<le>\<^sub>h h\<rbrakk> \<Longrightarrow> h1 \<le>\<^sub>h h2 \<or> h2 \<le>\<^sub>h h1"
-  -- "a hash has a unique parent"
+  and bot::"'v" ("\<bottom>")
 begin
 
-lemmas casper_assms = casper_axioms casper_def class.linorder_def class.order_def
+lemmas casper_assms_def = casper_def class.linorder_def class.order_def
     class.preorder_def class.order_axioms_def class.linorder_axioms_def byz_quorums_def
+    class.order_bot_def class.order_bot_axioms_def
 
-definition is_pred where "is_pred h1 h2 \<equiv> h1 <\<^sub>h h2 \<and> (\<forall> h . \<not> (h1 <\<^sub>h h \<and> h <\<^sub>h h2))"
+definition is_pred where 
+  -- "predecessor"
+  "is_pred h1 h2 \<equiv> h1 <\<^sub>h h2 \<and> (\<forall> h . \<not> (h1 <\<^sub>h h \<and> h <\<^sub>h h2))" 
+notation is_pred (infix "\<leftarrow>" 50)
+
+text {* All messages in epoch @{term \<bottom>} are ignored;  @{term \<bottom>} is used as a special value. *}
 
 definition prepared where 
-  "prepared s q h v1 v2 \<equiv> \<forall> n . member_1 n q \<longrightarrow> prepare_msg s n h v1 v2"
+  "prepared s q h v1 v2 \<equiv> v1 \<noteq> \<bottom> \<and> (\<forall> n . n \<in>\<^sub>1 q \<longrightarrow> prepare_msg s n h v1 v2)"
 definition committed where
-  "committed s q h v \<equiv> \<forall> n . member_1 n q \<longrightarrow> commit_msg s n h v"
+  "committed s q h v \<equiv> v \<noteq> bot \<and> (\<forall> n . n \<in>\<^sub>1 q \<longrightarrow> commit_msg s n h v)"
 definition fork where 
   "fork s \<equiv> \<exists> h1 h2 q1 q2 v1 v2 . committed s q1 h1 v1 \<and> committed s q2 h2 v2
     \<and> \<not>(h2 \<le>\<^sub>h h1 \<or> h1 \<le>\<^sub>h h2)"
 
 definition slashed_1 where  "slashed_1 s n \<equiv> 
-  \<exists> h v . commit_msg s n h v \<and> (\<forall> q v2 . v2 \<le>\<^sub>v v \<longrightarrow> \<not>prepared s q h v v2)"
-definition slashed_2 where "slashed_2 s n \<equiv>
+  \<exists> h v . commit_msg s n h v \<and> (\<forall> q v2 . v2 <\<^sub>v v \<longrightarrow> \<not>prepared s q h v v2)"
+definition slashed_2 where
+  "slashed_2 s n \<equiv>
   \<exists> h v1 v2 . prepare_msg s n h v1 v2 \<and> v2 \<noteq> \<bottom> \<and>
-    (\<forall> v3 q h2 . v3 \<le>\<^sub>v v2 \<longrightarrow> \<not>(prepared s q h2 v2 v3 \<and> is_pred h2 h))"
-definition slashed_3 where "slashed_3 s n \<equiv>
+    (\<forall> v3 q h2 . v3 <\<^sub>v v2 \<longrightarrow> \<not>(h2 \<leftarrow> h \<and> prepared s q h2 v2 v3))"
+definition slashed_3 where 
+  "slashed_3 s n \<equiv>
   \<exists> h1 h2 v1 v2 v3 . v1 <\<^sub>v v2 \<and> v3 <\<^sub>v v1 \<and> 
     commit_msg s n h1 v1 \<and> prepare_msg s n h2 v2 v3"
-definition slashed_4 where "slashed_4 s n \<equiv>
-  \<exists> h1 h2 v v1 v2 . (h1 \<noteq> h2 \<or> v1 \<noteq> v2) \<and> 
+definition slashed_4 where
+  "slashed_4 s n \<equiv> \<exists> h1 h2 v v1 v2 . (h1 \<noteq> h2 \<or> v1 \<noteq> v2) \<and> 
     prepare_msg s n h1 v v1 \<and> prepare_msg s n h2 v v2"
+
+definition slashed_2a where "slashed_2a s n \<equiv>
+  \<exists> h v1 . prepare_msg s n h v1 \<bottom> \<and> 
+    (\<forall> h2 q v2 . h2 \<leftarrow> h \<longrightarrow> \<not>prepared s q h2 \<bottom> v2)"
+definition slashed_5 where 
+  "slashed_5 s n \<equiv> \<exists> h v1 v2 . prepare_msg s n h v1 v2 \<and> v1 \<noteq> \<bottom> \<and> v1 \<le>\<^sub>v v2"
+
 definition slashed where "slashed s n \<equiv> 
-  slashed_1 s n \<or> slashed_2 s n \<or> slashed_3 s n \<or> slashed_4 s n"
+  slashed_1 s n \<or> slashed_2 s n \<or> slashed_3 s n \<or>  slashed_4 s n"
 
-lemma assumes "fork s" 
-  shows "\<exists> q . \<forall> n . member_2 n q \<longrightarrow> slashed s n"
-  using [[show_types]]
-  nitpick[verbose, card 'b=2, card 'c=2, card 'a=5, card 'v=2, card 'h=3, card 'd=1,
-      card "('a, 'h, 'v, 'd) state_scheme" = 1, dont_box]
-
-end
-
-end
+lemma assumes "fork s"
+  shows "\<exists> q . \<forall> n . n \<in>\<^sub>2 q \<longrightarrow> slashed s n"
+  using [[]]
+  nitpick[verbose, card 'b=2, card 'c=2, card 'a=5, card 'v=6, card 'h=5, card 'd=1,
+      card "('a, 'h, 'v, 'd) state_scheme" = 1, dont_box] (*,
+      eval="(slashed s, committed s)"] *)
+  using assms casper_axioms
+  apply -
+  unfolding slashed_def slashed_1_def slashed_2_def slashed_4_def slashed_3_def
+      prepared_def is_pred_def fork_def committed_def slashed_2a_def
+  apply (cases s)
+  apply simp
+  unfolding casper_assms_def
+  apply (simp (no_asm_use))
+  apply (match premises in P[thin]:"?x = ?y" \<Rightarrow> \<open>-\<close>)
+  apply clarify
+  using [[smt_timeout=3000,smt_oracle=true,smt_random_seed=4542,smt_certificates="./casper.cert"]]
+  sledgehammer[timeout=5000, provers=z3 spass]()
 
 
 end

--- a/Casper.thy
+++ b/Casper.thy
@@ -17,21 +17,24 @@ record ('n,'h,'v)state =
 locale casper = byz_quorums +
   views:linorder view_less_eq view_less + 
   order_bot  bot view_less_eq view_less for
-  hash_less_eq :: "'h \<Rightarrow> 'h \<Rightarrow> bool" (infix "\<le>\<^sub>h" 50)
-  and hash_less :: "'h \<Rightarrow> 'h \<Rightarrow> bool" (infix "<\<^sub>h" 50)
-  and view_less_eq :: "'v \<Rightarrow> 'v \<Rightarrow> bool" (infix "\<le>\<^sub>v" 50)
+  view_less_eq :: "'v \<Rightarrow> 'v \<Rightarrow> bool" (infix "\<le>\<^sub>v" 50)
   and view_less :: "'v \<Rightarrow> 'v \<Rightarrow> bool" (infix "<\<^sub>v" 50)
-  and bot::"'v" ("\<bottom>")
+  and bot::"'v" ("\<bottom>") +
+fixes 
+  hash_pred :: "'h \<Rightarrow> 'h \<Rightarrow> bool" (infix "\<leftarrow>" 50)
+assumes
+  -- "a hash has at most one predecessor which is not itself"
+  "\<And> h1 h2 . h1 \<leftarrow> h2 \<Longrightarrow> h1 \<noteq> h2"
+  and "\<And> h1 h2 h3 . \<lbrakk>h2 \<leftarrow> h1; h3 \<leftarrow> h1\<rbrakk> \<Longrightarrow> h2 = h3"
 begin
+
+inductive hash_ancestor (infix "\<leftarrow>\<^sup>*" 50) where 
+  "h1 \<leftarrow> h2 \<Longrightarrow> h1 \<leftarrow>\<^sup>* h2"
+| "\<lbrakk>h1 \<leftarrow>\<^sup>* h2; h2 \<leftarrow>\<^sup>* h3\<rbrakk> \<Longrightarrow> h1 \<leftarrow>\<^sup>* h3"
 
 lemmas casper_assms_def = casper_def class.linorder_def class.order_def
     class.preorder_def class.order_axioms_def class.linorder_axioms_def byz_quorums_def
     class.order_bot_def class.order_bot_axioms_def
-
-definition is_pred where 
-  -- "predecessor"
-  "is_pred h1 h2 \<equiv> h1 <\<^sub>h h2 \<and> (\<forall> h . \<not> (h1 <\<^sub>h h \<and> h <\<^sub>h h2))" 
-notation is_pred (infix "\<leftarrow>" 50)
 
 text {* All messages in epoch @{term \<bottom>} are ignored;  @{term \<bottom>} is used as a special value. *}
 
@@ -41,11 +44,12 @@ definition committed where
   "committed s q h v \<equiv> v \<noteq> bot \<and> (\<forall> n . n \<in>\<^sub>1 q \<longrightarrow> commit_msg s n h v)"
 definition fork where 
   "fork s \<equiv> \<exists> h1 h2 q1 q2 v1 v2 . committed s q1 h1 v1 \<and> committed s q2 h2 v2
-    \<and> \<not>(h2 \<le>\<^sub>h h1 \<or> h1 \<le>\<^sub>h h2)"
+    \<and> \<not>(h2 \<leftarrow>\<^sup>* h1 \<or> h1 \<leftarrow>\<^sup>* h2 \<or> h1 = h2)"
 
 definition slashed_1 where  "slashed_1 s n \<equiv> 
   \<exists> h v . commit_msg s n h v \<and> (\<forall> q v2 . v2 <\<^sub>v v \<longrightarrow> \<not>prepared s q h v v2)"
 definition slashed_2 where
+  -- "this is not exactly what Vitalik wrote."
   "slashed_2 s n \<equiv>
   \<exists> h v1 v2 . prepare_msg s n h v1 v2 \<and> v2 \<noteq> \<bottom> \<and>
     (\<forall> v3 q h2 . v3 <\<^sub>v v2 \<longrightarrow> \<not>(h2 \<leftarrow> h \<and> prepared s q h2 v2 v3))"
@@ -57,32 +61,27 @@ definition slashed_4 where
   "slashed_4 s n \<equiv> \<exists> h1 h2 v v1 v2 . (h1 \<noteq> h2 \<or> v1 \<noteq> v2) \<and> 
     prepare_msg s n h1 v v1 \<and> prepare_msg s n h2 v v2"
 
-definition slashed_2a where "slashed_2a s n \<equiv>
-  \<exists> h v1 . prepare_msg s n h v1 \<bottom> \<and> 
-    (\<forall> h2 q v2 . h2 \<leftarrow> h \<longrightarrow> \<not>prepared s q h2 \<bottom> v2)"
-definition slashed_5 where 
-  "slashed_5 s n \<equiv> \<exists> h v1 v2 . prepare_msg s n h v1 v2 \<and> v1 \<noteq> \<bottom> \<and> v1 \<le>\<^sub>v v2"
-
 definition slashed where "slashed s n \<equiv> 
   slashed_1 s n \<or> slashed_2 s n \<or> slashed_3 s n \<or>  slashed_4 s n"
 
 lemma assumes "fork s"
   shows "\<exists> q . \<forall> n . n \<in>\<^sub>2 q \<longrightarrow> slashed s n"
   using [[]]
-  nitpick[verbose, card 'b=2, card 'c=2, card 'a=5, card 'v=6, card 'h=5, card 'd=1,
-      card "('a, 'h, 'v, 'd) state_scheme" = 1, dont_box] (*,
+  nitpick[verbose, card 'b=2, card 'c=2, card 'a=5, card 'v=8, card 'h=7, card 'd=1,
+      card "('a, 'h, 'v, 'd) state_scheme" = 1, dont_box, timeout=300] (*,
       eval="(slashed s, committed s)"] *)
   using assms casper_axioms
   apply -
   unfolding slashed_def slashed_1_def slashed_2_def slashed_4_def slashed_3_def
-      prepared_def is_pred_def fork_def committed_def slashed_2a_def
+      prepared_def fork_def committed_def slashed_2a_def
   apply (cases s)
   apply simp
   unfolding casper_assms_def
   apply (simp (no_asm_use))
   apply (match premises in P[thin]:"?x = ?y" \<Rightarrow> \<open>-\<close>)
   apply clarify
-  using [[smt_timeout=3000,smt_oracle=true,smt_random_seed=4542,smt_certificates="./casper.cert"]]
+  oops
+  using [[smt_timeout=3000,smt_oracle=true,smt_random_seed=456363655542,smt_certificates="./casper.cert"]]
   sledgehammer[timeout=5000, provers=z3 spass]()
 
 

--- a/Casper.thy
+++ b/Casper.thy
@@ -30,9 +30,9 @@ begin
 
 inductive hash_ancestor (infix "\<leftarrow>\<^sup>*" 50) where 
   "h1 \<leftarrow> h2 \<Longrightarrow> h1 \<leftarrow>\<^sup>* h2"
-| "\<lbrakk>h1 \<leftarrow>\<^sup>* h2; h2 \<leftarrow>\<^sup>* h3\<rbrakk> \<Longrightarrow> h1 \<leftarrow>\<^sup>* h3"
+| "\<lbrakk>h1 \<leftarrow> h2; h2 \<leftarrow>\<^sup>* h3\<rbrakk> \<Longrightarrow> h1 \<leftarrow>\<^sup>* h3"
 
-lemmas casper_assms_def = casper_def class.linorder_def class.order_def
+lemmas casper_assms_def = casper_def casper_axioms_def class.linorder_def class.order_def
     class.preorder_def class.order_axioms_def class.linorder_axioms_def byz_quorums_def
     class.order_bot_def class.order_bot_axioms_def
 
@@ -67,21 +67,21 @@ definition slashed where "slashed s n \<equiv>
 lemma assumes "fork s"
   shows "\<exists> q . \<forall> n . n \<in>\<^sub>2 q \<longrightarrow> slashed s n"
   using [[]]
-  nitpick[verbose, card 'b=2, card 'c=2, card 'a=5, card 'v=8, card 'h=7, card 'd=1,
+  nitpick[verbose, card 'b=2, card 'c=2, card 'a=5, card 'v=4, card 'h=3, card 'd=1,
       card "('a, 'h, 'v, 'd) state_scheme" = 1, dont_box, timeout=300] (*,
       eval="(slashed s, committed s)"] *)
   using assms casper_axioms
   apply -
   unfolding slashed_def slashed_1_def slashed_2_def slashed_4_def slashed_3_def
-      prepared_def fork_def committed_def slashed_2a_def
+      prepared_def fork_def committed_def
   apply (cases s)
   apply simp
+  using hash_ancestor.intros
   unfolding casper_assms_def
   apply (simp (no_asm_use))
   apply (match premises in P[thin]:"?x = ?y" \<Rightarrow> \<open>-\<close>)
   apply clarify
-  oops
-  using [[smt_timeout=3000,smt_oracle=true,smt_random_seed=456363655542,smt_certificates="./casper.cert"]]
+  using [[smt_infer_triggers,smt_timeout=3000,smt_oracle=true,smt_random_seed=8789797972,smt_certificates="./casper.cert"]]
   sledgehammer[timeout=5000, provers=z3 spass]()
 
 

--- a/Casper.thy
+++ b/Casper.thy
@@ -87,7 +87,7 @@ lemma l1: assumes "prepared s q1 h1 v1 v2" and "committed s q2 h2 v3" and "v1 > 
 (*<*)  nitpick[verbose, card 'b=1, card 'c=1, card 'a=1, card nat=5, card 'h=4, card 'd=1,
       card "('a, 'h, 'd) state_scheme" = 1, dont_box, timeout=300, eval="fork s"] (*>*)
   using assms casper_axioms linorder_axioms[where ?'a=nat] unfolding casper_defs order_defs
-  by smt
+  by metis
 
 lemma l2: assumes "nth_ancestor n h1 h2" and "nth_ancestor m h2 h3" 
   shows "nth_ancestor (n+m) h1 h3" 
@@ -111,7 +111,7 @@ proof -
       proof (cases "v2=v3")
         case True
         then show ?thesis using less(2-5) casper_axioms linorder_axioms[where ?'a=nat]
-          using [[smt_solver=cvc4]] by (simp add: casper_defs, unfold order_defs) smt
+          using [[smt_solver=cvc4]] by (auto simp add: casper_defs, unfold order_defs) smt
       next
         case False
         obtain q3 h3 v4 where 1:"nth_ancestor (v1-v2) h3 h1" and 2:"prepared s q3 h3 v2 v4"

--- a/Casper.thy
+++ b/Casper.thy
@@ -10,16 +10,11 @@ locale byz_quorums =
     (* and "\<And> q . \<exists> n . n \<in>\<^sub>2 q" *)
 
 record ('n,'h,'v)state =
-  -- "@{typ 'n} is the type of validators (nodes), @{typ 'h} hashes, and @{typ 'v} views"
-  commit_msg :: "'n \<Rightarrow> 'h \<Rightarrow> 'v \<Rightarrow> bool"
-  prepare_msg :: "'n \<Rightarrow> 'h \<Rightarrow> 'v \<Rightarrow> 'v \<Rightarrow> bool"
+  -- "@{typ 'n} is the type of validators (nodes), @{typ 'h} hashes, and @{typ nat} views"
+  commit_msg :: "'n \<Rightarrow> 'h \<Rightarrow> nat \<Rightarrow> bool"
+  prepare_msg :: "'n \<Rightarrow> 'h \<Rightarrow> nat \<Rightarrow> 'v \<Rightarrow> bool"
 
 locale casper = byz_quorums +
-  views:linorder view_less_eq view_less + 
-  order_bot  bot view_less_eq view_less for
-  view_less_eq :: "'v \<Rightarrow> 'v \<Rightarrow> bool" (infix "\<le>\<^sub>v" 50)
-  and view_less :: "'v \<Rightarrow> 'v \<Rightarrow> bool" (infix "<\<^sub>v" 50)
-  and bot::"'v" ("\<bottom>") +
 fixes 
   hash_pred :: "'h \<Rightarrow> 'h \<Rightarrow> bool" (infix "\<leftarrow>" 50)
 assumes
@@ -31,44 +26,76 @@ begin
 inductive hash_ancestor (infix "\<leftarrow>\<^sup>*" 50) where 
   "h1 \<leftarrow> h2 \<Longrightarrow> h1 \<leftarrow>\<^sup>* h2"
 | "\<lbrakk>h1 \<leftarrow> h2; h2 \<leftarrow>\<^sup>* h3\<rbrakk> \<Longrightarrow> h1 \<leftarrow>\<^sup>* h3"
+declare hash_ancestor.intros[simp,intro]
+
+inductive nth_parent :: "nat \<Rightarrow> 'h \<Rightarrow> 'h \<Rightarrow> bool" where 
+  "nth_parent 0 h1 h1"
+| "\<lbrakk>nth_parent n h1 h2; h2 \<leftarrow> h3\<rbrakk> \<Longrightarrow> nth_parent (n+1) h1 h3"
+declare nth_parent.intros[simp,intro]
+
+inductive_cases test2:"nth_parent 1 h1 h2"
+thm test2
 
 lemmas casper_assms_def = casper_def casper_axioms_def class.linorder_def class.order_def
     class.preorder_def class.order_axioms_def class.linorder_axioms_def byz_quorums_def
     class.order_bot_def class.order_bot_axioms_def
 
-text {* All messages in epoch @{term \<bottom>} are ignored;  @{term \<bottom>} is used as a special value. *}
+text {* All messages in epoch @{term 0} are ignored;  @{term 0} is used as a special value. *}
 
 definition prepared where 
-  "prepared s q h v1 v2 \<equiv> v1 \<noteq> \<bottom> \<and> (\<forall> n . n \<in>\<^sub>1 q \<longrightarrow> prepare_msg s n h v1 v2)"
+  "prepared s q h v1 v2 \<equiv> v1 \<noteq> 0 \<and> (\<forall> n . n \<in>\<^sub>1 q \<longrightarrow> prepare_msg s n h v1 v2)"
 definition committed where
-  "committed s q h v \<equiv> v \<noteq> bot \<and> (\<forall> n . n \<in>\<^sub>1 q \<longrightarrow> commit_msg s n h v)"
+  "committed s q h v \<equiv> v \<noteq> 0 \<and> (\<forall> n . n \<in>\<^sub>1 q \<longrightarrow> commit_msg s n h v)"
 definition fork where 
   "fork s \<equiv> \<exists> h1 h2 q1 q2 v1 v2 . committed s q1 h1 v1 \<and> committed s q2 h2 v2
     \<and> \<not>(h2 \<leftarrow>\<^sup>* h1 \<or> h1 \<leftarrow>\<^sup>* h2 \<or> h1 = h2)"
 
 definition slashed_1 where  "slashed_1 s n \<equiv> 
-  \<exists> h v . commit_msg s n h v \<and> (\<forall> q v2 . v2 <\<^sub>v v \<longrightarrow> \<not>prepared s q h v v2)"
+  \<exists> h v . commit_msg s n h v \<and> (\<forall> q v2 . v2 < v \<longrightarrow> \<not>prepared s q h v v2)"
 definition slashed_2 where
-  -- "this is not exactly what Vitalik wrote."
   "slashed_2 s n \<equiv>
-  \<exists> h v1 v2 . prepare_msg s n h v1 v2 \<and> v2 \<noteq> \<bottom> \<and>
-    (\<forall> v3 q h2 . v3 <\<^sub>v v2 \<longrightarrow> \<not>(h2 \<leftarrow> h \<and> prepared s q h2 v2 v3))"
+  \<exists> h v1 v2 . prepare_msg s n h v1 v2 \<and> v2 \<noteq> 0 \<and>
+    (\<forall> v3 q h2 . v3 < v2 \<longrightarrow> \<not>(nth_parent (v1 - v2) h2 h \<and> prepared s q h2 v2 v3))"
+definition slashed_2' where
+  -- "this is not exactly what Vitalik wrote."
+  "slashed_2' s n \<equiv>
+  \<exists> h v1 v2 . prepare_msg s n h v1 v2 \<and> v2 \<noteq> 0 \<and>
+    (\<forall> v3 q h2 . v3 < v2 \<longrightarrow> \<not>(h2 \<leftarrow> h \<and> prepared s q h2 v2 v3))"
 definition slashed_3 where 
   "slashed_3 s n \<equiv>
-  \<exists> h1 h2 v1 v2 v3 . v1 <\<^sub>v v2 \<and> v3 <\<^sub>v v1 \<and> 
+  \<exists> h1 h2 v1 v2 v3 . v1 < v2 \<and> v3 < v1 \<and> 
     commit_msg s n h1 v1 \<and> prepare_msg s n h2 v2 v3"
 definition slashed_4 where
   "slashed_4 s n \<equiv> \<exists> h1 h2 v v1 v2 . (h1 \<noteq> h2 \<or> v1 \<noteq> v2) \<and> 
     prepare_msg s n h1 v v1 \<and> prepare_msg s n h2 v v2"
 
 definition slashed where "slashed s n \<equiv> 
-  slashed_1 s n \<or> slashed_2 s n \<or> slashed_3 s n \<or>  slashed_4 s n"
+  slashed_1 s n \<or> slashed_2 s n \<or> slashed_3 s n \<or> slashed_4 s n"
+
+lemma assumes "prepared s q h1 v1 v2" and "committed s q h2 v2" and "v1 > v2"
+  and "\<not>nth_parent (v1 - v2) h2 h1"
+shows "\<exists> q . \<forall> n . n \<in>\<^sub>2 q \<longrightarrow> slashed s n"
+  using assms
+proof (induct "v1 - v2 - 1")
+  case 0
+  have "\<not>h2 \<leftarrow> h1"
+    by (metis "0.hyps" Nat.add_0_right One_nat_def Suc_diff_Suc add_Suc_right assms(3) assms(4) diff_diff_left nth_parent.intros(1) nth_parent.intros(2))  
+  then show ?case using 0
+  using assms casper_axioms nth_parent.intros
+  unfolding slashed_def slashed_1_def slashed_2_def slashed_4_def slashed_3_def
+      prepared_def fork_def committed_def casper_assms_def
+  apply auto
+  using [[smt_infer_triggers,smt_timeout=3000,smt_oracle=true,smt_random_seed=3143,smt_certificates="./casper.cert"]]
+next
+  case (Suc x)
+  then show ?case sorry
+qed oops
 
 lemma assumes "fork s"
-  shows "\<exists> q . \<forall> n . n \<in>\<^sub>2 q \<longrightarrow> slashed s n"
+  shows "\<exists> q . \<forall> n . n \<in>\<^sub>2 q \<longrightarrow> slashed s n" oops
   using [[]]
-  nitpick[verbose, card 'b=2, card 'c=2, card 'a=5, card 'v=4, card 'h=3, card 'd=1,
-      card "('a, 'h, 'v, 'd) state_scheme" = 1, dont_box, timeout=300] (*,
+  nitpick[verbose, card 'b=2, card 'c=2, card 'a=5, card nat=5, card 'h=4, card 'd=1,
+      card "('a, 'h, nat, 'd) state_scheme" = 1, dont_box, timeout=300] (*,
       eval="(slashed s, committed s)"] *)
   using assms casper_axioms
   apply -
@@ -76,11 +103,11 @@ lemma assumes "fork s"
       prepared_def fork_def committed_def
   apply (cases s)
   apply simp
-  using hash_ancestor.intros
+  using hash_ancestor.intros nth_parent.intros
   unfolding casper_assms_def
   apply (simp (no_asm_use))
   apply (match premises in P[thin]:"?x = ?y" \<Rightarrow> \<open>-\<close>)
-  apply clarify
+  apply clarify oops
   using [[smt_infer_triggers,smt_timeout=3000,smt_oracle=true,smt_random_seed=8789797972,smt_certificates="./casper.cert"]]
   sledgehammer[timeout=5000, provers=z3 spass]()
 


### PR DESCRIPTION
Hi Yoichi, 
I created another model and proof of accountable safety based on your work, but which reduces the proof to a few dozen lines. The trick is to model things in uninterpreted first-order logic as much as possible in order to maximize the effectiveness of methods such as metis and smt. For examples I model quorums using a uninterpreted type 'q1 instead of sets of validators, and then I make locale assumptions in first-order logic corresponding to the intersection properties of quorums (one can provide an instantiation later on to get rid of the axioms). Another example is abstracting nat to a linear order, whose properties are expressible in first-order logic (linorder_axioms in Isabelle/HOL).

I thought you might be interested in the technique, and maybe in using it for future work on verifying pos stuff.